### PR TITLE
List kun tabeller med "område" som variable

### DIFF
--- a/statistikbanken_api.py
+++ b/statistikbanken_api.py
@@ -45,6 +45,27 @@ class Statbank_api():
         data = {'subjects': subject_ids, 'format': 'JSON'}
         return self.get_json(self.url, 'subjects', data)
 
+    def has_municipalities(self, subject):
+        '''Returning tables within a subject with "område" as an variable,
+        indicating data might hold municipality code as an geographic reference'''
+        endpoint = 'tables'
+        post_body = \
+            {
+                "subjects": [
+                    subject
+                ]
+            }
+
+        tables = self.get_json(self.url, endpoint, post_body)
+
+        table_list = []
+
+        for table in tables:
+            if u'område' in table['variables']:
+                table_list.append(table)
+
+        return table_list
+
     def get_variables(self,table_id):
         '''
         Henter variabler og værdier for en tabel


### PR DESCRIPTION
Lavet metode til at finde tabeller i et subject som har 'område' som variable. Tænkt filtrering til kun at medtage de tabeller der har en kommunekode som geografisk reference.  #2 

Tanken er at denne metode skal ind i logikken bag brugergrænsefladen, så vi kun lister de tabeller der kan vises på kort vha. kommunekode/regionskode. 

Dette skal dog nok forfines ved at bruge metadata endpoint hvor man får oplyst variable værdier.

